### PR TITLE
AI-79 replaced cx_Oracle with oracledb

### DIFF
--- a/sql_extract/__init__.py
+++ b/sql_extract/__init__.py
@@ -3,7 +3,6 @@
 Utility functions and class for sql-extract
 """
 import sys
-import io
 import os
 import re
 import csv
@@ -11,7 +10,7 @@ import openpyxl
 import logging
 import argparse
 from profpy.db import get_cx_oracle_connection
-from cx_Oracle import DatabaseError
+from oracledb import DatabaseError
 
 
 class SqlExtractHandler(object):


### PR DESCRIPTION
Upgrading cx_Oracle to oracledb to coincide with profpy oracledb upgrade and the renaming of cx_Oracle python module.